### PR TITLE
Change errors to HTML templates

### DIFF
--- a/neutrinoapp/src/App.jsx
+++ b/neutrinoapp/src/App.jsx
@@ -8,6 +8,7 @@ import Home from './Home'
 import Search from './Search'
 import Result from './Result'
 import Page_404 from './Page_404'
+import Page_Error from './Page_Error'
 
 export default function App () {
   return (
@@ -28,6 +29,10 @@ export default function App () {
         <Route
           path='/entity/:id'
           element={<Result />}
+        />
+        <Route
+          path='/error/'
+          element={<Page_Error />}
         />
       </Routes>
     </Router>

--- a/neutrinoapp/src/App.jsx
+++ b/neutrinoapp/src/App.jsx
@@ -7,11 +7,16 @@ import {
 import Home from './Home'
 import Search from './Search'
 import Result from './Result'
+import Page_404 from './Page_404'
 
 export default function App () {
   return (
     <Router basename='/'>
       <Routes>
+        <Route
+          path='*'
+          element={<Page_404 />}
+        />
         <Route
           path='/'
           element={<Home />}

--- a/neutrinoapp/src/Page_404.jsx
+++ b/neutrinoapp/src/Page_404.jsx
@@ -1,0 +1,19 @@
+import React, { useState } from 'react'
+import './App.css'
+
+export default function Search () {
+
+  return (
+    <div className='App'>
+      <div id='404'>
+        <h1>404</h1>
+        <h2>Page not found</h2>
+        <p>
+          If you typed the web address, check it is correct.<br></br>
+
+          If you pasted the web address, check you copied the entire address.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/neutrinoapp/src/Page_Error.jsx
+++ b/neutrinoapp/src/Page_Error.jsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react'
+import {
+  useSearchParams,
+  Link
+} from 'react-router-dom'
+import './App.css'
+
+export default function Search () {
+  const [searchParams] = useSearchParams()
+  var error = searchParams.get('error')
+  var text = searchParams.get('text')
+  var message = searchParams.get('message')
+ 
+  return (
+    <div className='App'>
+      <div id='error'>
+        <h1>{error}</h1>
+        <h2>{text}</h2>
+        <p>
+            {message}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/neutrinoapp/src/Result.jsx
+++ b/neutrinoapp/src/Result.jsx
@@ -15,9 +15,17 @@ export default function Result () {
   const getData = async () => {
     setIsActive(true)
     try {
+      var resp = ""
       fetch('http://ec2-13-40-156-226.eu-west-2.compute.amazonaws.com:5000/api/moving-images-ent/entity/' + id)
         .then(response => response.json())
         .then(response => {
+          resp = response
+          return response.json()
+        })
+        .then(response => {
+          if (!resp.ok) {
+            window.location.href = '/error/?error='+resp.status+'&text='+resp.statusText+'&message='+response.message
+          }
           setDisplayWiki(response.items)
         })
         .then(response => setIsReady(true))

--- a/neutrinoapp/src/Result.jsx
+++ b/neutrinoapp/src/Result.jsx
@@ -17,7 +17,6 @@ export default function Result () {
     try {
       var resp = ""
       fetch('http://ec2-13-40-34-76.eu-west-2.compute.amazonaws.com:5000/api/moving-images-ent/entity/' + id)
-        .then(response => response.json())
         .then(response => {
           resp = response
           return response.json()

--- a/neutrinoapp/src/Result.jsx
+++ b/neutrinoapp/src/Result.jsx
@@ -16,7 +16,7 @@ export default function Result () {
     setIsActive(true)
     try {
       var resp = ""
-      fetch('http://ec2-13-40-156-226.eu-west-2.compute.amazonaws.com:5000/api/moving-images-ent/entity/' + id)
+      fetch('http://ec2-13-40-34-76.eu-west-2.compute.amazonaws.com:5000/api/moving-images-ent/entity/' + id)
         .then(response => response.json())
         .then(response => {
           resp = response

--- a/neutrinoapp/src/Search.jsx
+++ b/neutrinoapp/src/Search.jsx
@@ -53,7 +53,6 @@ export default function Search () {
     try {
       var resp = ""
       fetch('http://ec2-13-40-34-76.eu-west-2.compute.amazonaws.com:5000/api/moving-images?page=' + pages + '&q=' + keyword)
-        .then(response => response.json())
         .then(response => {
           resp = response
           return response.json()

--- a/neutrinoapp/src/Search.jsx
+++ b/neutrinoapp/src/Search.jsx
@@ -51,9 +51,17 @@ export default function Search () {
     setInitQuery(true)
     const pageNumber = Math.max(1, pages)
     try {
+      var resp = ""
       fetch('http://ec2-13-40-156-226.eu-west-2.compute.amazonaws.com:5000/api/moving-images?page=' + pages + '&q=' + keyword)
         .then(response => response.json())
         .then(response => {
+          resp = response
+          return response.json()
+        })
+        .then(response => {
+          if (!resp.ok) {
+            window.location.href = '/error/?error='+resp.status+'&text='+resp.statusText+'&message='+response.message
+          }
           setPageCount(Math.ceil(response.total / PER_PAGE))
           setDisplayWiki(response.items)
         })
@@ -65,15 +73,33 @@ export default function Search () {
   }
 
   const getDiscoveryTNA = async () => {
+    var resp = ""
     fetch('http://ec2-13-40-156-226.eu-west-2.compute.amazonaws.com:5000/api/discovery?source=TNA&q=' + keyword)
-      .then(response => response.json())
-      .then(response => setDisplayTNA(response.records))
+      .then(response => {
+        resp = response
+        return response.json()
+      })
+      .then(response => {
+        if (!resp.ok) {
+          window.location.href = '/error/?error='+resp.status+'&text='+resp.statusText+'&message='+response.message
+        }
+        setDisplayTNA(response.records)
+      })
   }
 
   const getDiscoveryOTH = async () => {
+    var resp = ""
     fetch('http://ec2-13-40-156-226.eu-west-2.compute.amazonaws.com:5000/api/discovery?source=OTH&q=' + keyword)
-      .then(response => response.json())
-      .then(response => setDisplayOther(response.records))
+      .then(response => {
+        resp = response
+        return response.json()
+      })
+      .then(response => {
+        if (!resp.ok) {
+          window.location.href = '/error/?error='+resp.status+'&text='+resp.statusText+'&message='+response.message
+        }
+        setDisplayTNA(response.records)
+      })
   }
 
   const search = async () => {

--- a/neutrinoapp/src/Search.jsx
+++ b/neutrinoapp/src/Search.jsx
@@ -52,7 +52,7 @@ export default function Search () {
     const pageNumber = Math.max(1, pages)
     try {
       var resp = ""
-      fetch('http://ec2-13-40-156-226.eu-west-2.compute.amazonaws.com:5000/api/moving-images?page=' + pages + '&q=' + keyword)
+      fetch('http://ec2-13-40-34-76.eu-west-2.compute.amazonaws.com:5000/api/moving-images?page=' + pages + '&q=' + keyword)
         .then(response => response.json())
         .then(response => {
           resp = response
@@ -74,7 +74,7 @@ export default function Search () {
 
   const getDiscoveryTNA = async () => {
     var resp = ""
-    fetch('http://ec2-13-40-156-226.eu-west-2.compute.amazonaws.com:5000/api/discovery?source=TNA&q=' + keyword)
+    fetch('http://ec2-13-40-34-76.eu-west-2.compute.amazonaws.com:5000/api/discovery?source=TNA&q=' + keyword)
       .then(response => {
         resp = response
         return response.json()
@@ -89,7 +89,7 @@ export default function Search () {
 
   const getDiscoveryOTH = async () => {
     var resp = ""
-    fetch('http://ec2-13-40-156-226.eu-west-2.compute.amazonaws.com:5000/api/discovery?source=OTH&q=' + keyword)
+    fetch('http://ec2-13-40-34-76.eu-west-2.compute.amazonaws.com:5000/api/discovery?source=OTH&q=' + keyword)
       .then(response => {
         resp = response
         return response.json()


### PR DESCRIPTION
PR Aim:

HTML template for error 404 when wrong url is hit.

HTML template for other errors (400, 500).

Redirecting to the error page.

Screenshots of page with errors:
![404](https://github.com/OurHeritageOurStories/prototype-1/assets/105294294/265aaec2-84d5-4110-8f2f-a0a0c8debf25)
![html](https://github.com/OurHeritageOurStories/prototype-1/assets/105294294/2077c6d8-c1be-4164-8bf4-8ced0e3b6f16)
